### PR TITLE
Updated version of clojurescript

### DIFF
--- a/labs/architecture-examples/om/project.clj
+++ b/labs/architecture-examples/om/project.clj
@@ -3,7 +3,7 @@
   :url "http://example.com/FIXME"
 
   :dependencies [[org.clojure/clojure "1.5.1"]
-                 [org.clojure/clojurescript "0.0-2125"]
+                 [org.clojure/clojurescript "0.0-2127"]
                  [org.clojure/core.async "0.1.267.0-0d7780-alpha"]
                  [secretary "0.4.0"]
                  [om "0.1.0-SNAPSHOT"]]


### PR DESCRIPTION
Cloning clojurescript master installs version 2127 to ~/.m2/org/clojure/...
