### PR TITLE
Keep toggle-all in sync with todos, add parentheses to completed count

### DIFF
--- a/labs/architecture-examples/om/src/todomvc/app.cljs
+++ b/labs/architecture-examples/om/src/todomvc/app.cljs
@@ -47,11 +47,12 @@
     :active (not (:completed todo))
     :completed (:completed todo)))
 
-(defn main [{:keys [showing] :as app} opts]
+(defn main [{:keys [showing todos] :as app} opts]
   (om/component
     (dom/section #js {:id "main"}
       (dom/input #js {:id "toggle-all" :type "checkbox"
-                      :onChange #(toggle-all % app)})
+                      :onChange #(toggle-all % app)
+                      :checked (every? #(:completed %) todos)})
       (dom/ul #js {:id "todo-list"}
         (into-array
           (map #(om/build item/todo-item app
@@ -70,7 +71,7 @@
                        (dom/button
                          #js {:id "clear-completed"
                               :onClick #(put! comm [:clear (now)])}
-                         (str "Clear completed " completed)))
+                         (str "Clear completed (" completed ")")))
         sel (-> (zipmap [:all :active :completed] (repeat ""))
                 (assoc showing "selected"))]
     (om/component


### PR DESCRIPTION
Automatically check the toggle-all checkbox when all todos are complete.

Uncheck toggle-all if some todos are not complete.

The box is checked when there are no todos, but I think this is fine as it should be set to display:none when there are no items.

This commit also adds parenthesis around the count of completed todos.
